### PR TITLE
Fix / Fix bug where restarting the container resulted in duplicate backups

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -5,9 +5,12 @@ set -e
 if [ "${SCHEDULE}" = "**None**" ]; then
   bash backup.sh
 else
-  echo "SHELL=/bin/bash" >> /etc/crontab
-  echo "$SCHEDULE root /usr/bin/env bash /backup.sh > /proc/\$(pgrep -u root -o cron)/fd/1 2>&1" >> /etc/crontab
-  echo "#" >> /etc/crontab
+  # Add backup to cron file only if it not already exists
+  if ! grep -q "root /usr/bin/env bash /backup.sh" /etc/crontab; then
+    echo "SHELL=/bin/bash" >> /etc/crontab
+    echo "$SCHEDULE root /usr/bin/env bash /backup.sh > /proc/\$(pgrep -u root -o cron)/fd/1 2>&1" >> /etc/crontab
+    echo "#" >> /etc/crontab
+  fi
   env > /etc/environment # dump env to file so we're able to get vars back when running a script from cron
   cron -f
 fi


### PR DESCRIPTION
When the backup container (re)started, it added the backup command to the crontab config. When it restarted multiple times, the backup command was added to crontab multiple times. With this PR the script checks if the command exist in `/etc/crontab` before adding it.

```bash
# Add backup to cron file only if it not already exists
if ! grep -q "[command string]" /etc/crontab; then
  # add command to cron
fi
```